### PR TITLE
Quick tip to generate trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Icons are from [Font Awesome](http://fortawesome.github.io/Font-Awesome/).
 Include the CSS file after Prism theme, and the JS file after Prism core.
 You may use `tree -F` to get a compatible text structure.
 
+It may be helpful to specify the charset in the `tree` command ie. `tree -F --charset=ascii` for some directory structures.
+
 ## Example code
 
 ```html


### PR DESCRIPTION
By default the `tree` command uses the utf-8 charset, and there are bugs sometimes with this which are fixed if `ascii` is specified (see #3). So just drawing attention to the option might help someone generate the correct input.