### PR TITLE
#5 Fixing dot directories appear as dot files

### DIFF
--- a/prism-treeview.js
+++ b/prism-treeview.js
@@ -54,10 +54,10 @@ Prism.hooks.add('wrap', function(env) {
 					// Ex. 'foo.min.js' would become '<span class="token keyword ext-min-js ext-js">foo.min.js</span>'
 					env.classes.push('ext-' + parts.join('-'));
 				}
-			}
-
-			if(env.content.charAt(0)==='.') {
-				env.classes.push('dotfile');
+				
+				if(env.content.charAt(0)==='.') {
+					env.classes.push('dotfile');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the issue described in #5

Postfix the output

```treeview
root/
|-- .github/
|   |-- actions/
|   |-- workflows/
|   |-- PULL_REQUEST_TEMPLATE/
|-- .gitignore
`-- README.md
```

![image](https://user-images.githubusercontent.com/25071773/183937734-9485a29a-eb1e-4588-a12d-debc47292259.png)
